### PR TITLE
커스텀 예외 처리 #28

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.4.1'
+    id 'org.springframework.boot' version '3.3.9'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/src/main/java/com/bss/bssserverapi/domain/User/controller/UserController.java
+++ b/src/main/java/com/bss/bssserverapi/domain/User/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.bss.bssserverapi.domain.User.controller;
 
+import com.bss.bssserverapi.global.exception.ErrorCode;
+import com.bss.bssserverapi.global.exception.GlobalException;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -9,8 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     @GetMapping
-    public String healthCheck(){
+    public void healthCheck(){
 
-        return "OK-2";
+        throw new GlobalException(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/bss/bssserverapi/domain/User/controller/UserController.java
+++ b/src/main/java/com/bss/bssserverapi/domain/User/controller/UserController.java
@@ -14,6 +14,6 @@ public class UserController {
     @GetMapping
     public void healthCheck(){
 
-        throw new GlobalException(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR);
+        throw new GlobalException(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.UNKNOWN_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/bss/bssserverapi/global/exception/ErrorCode.java
+++ b/src/main/java/com/bss/bssserverapi/global/exception/ErrorCode.java
@@ -1,8 +1,10 @@
 package com.bss.bssserverapi.global.exception;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 
 @Getter
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorCode {
 
     // auth
@@ -10,7 +12,7 @@ public enum ErrorCode {
     // business
 
     // common
-    INTERNAL_SERVER_ERROR("C001", "Internal Server Error"),
+    UNKNOWN_SERVER_ERROR("C001", "Unknown Server Error"),
     ;
 
     private final String code;

--- a/src/main/java/com/bss/bssserverapi/global/exception/ErrorCode.java
+++ b/src/main/java/com/bss/bssserverapi/global/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.bss.bssserverapi.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    // auth
+
+    // business
+
+    // common
+    INTERNAL_SERVER_ERROR("C001", "Internal Server Error"),
+    ;
+
+    private final String code;
+    private final String message;
+
+    ErrorCode(final String code, final String message){
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/bss/bssserverapi/global/exception/GlobalException.java
+++ b/src/main/java/com/bss/bssserverapi/global/exception/GlobalException.java
@@ -1,0 +1,17 @@
+package com.bss.bssserverapi.global.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class GlobalException extends RuntimeException{
+
+    private final HttpStatus httpStatus;
+    private final ErrorCode errorCode;
+
+    public GlobalException(final HttpStatus httpStatus, final ErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/bss/bssserverapi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bss/bssserverapi/global/exception/GlobalExceptionHandler.java
@@ -1,17 +1,35 @@
 package com.bss.bssserverapi.global.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    // TODO: IllegalArgumentException, MethodArgumentNotValidException, etc..
+
+    /**
+     * 커스텀 예외 처리
+     */
     @ExceptionHandler(GlobalException.class)
-    public ResponseEntity<?> handleGlobalException(GlobalException e){
+    public ResponseEntity<?> handleGlobalException(final GlobalException e){
 
         return ResponseEntity
                 .status(e.getHttpStatus())
                 .body(e.getErrorCode());
+    }
+
+    /**
+     * 그 외 모든 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> handleException(final Exception e){
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorCode.UNKNOWN_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/bss/bssserverapi/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/bss/bssserverapi/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.bss.bssserverapi.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<?> handleGlobalException(GlobalException e){
+
+        return ResponseEntity
+                .status(e.getHttpStatus())
+                .body(e.getErrorCode());
+    }
+}


### PR DESCRIPTION
## Issue
- close #28 
## 💡 구현 기능
- GlobalExceptionHandler, GlobalException, ErrorCode 작성
## ⁉️ 기타
- ControllerAdvice와 Swagger간 충돌 문제 해결
[참고] https://dev-meung.tistory.com/entry/%ED%95%B4%EC%BB%A4%ED%86%A4-HY-THON-%ED%8A%B8%EB%9F%AC%EB%B8%94%EC%8A%88%ED%8C%85-Swagger-500-%EC%97%90%EB%9F%AC-Failed-to-load-API-definition
- 현재 GlobalExceptionHandler에는 GlobalException과 Exception만 처리중. 추후 다른 예외들도 추가 필요
## ⏰ 소요 시간
- 추정 시간: 1h
- 소요 시간: 2h