### PR TITLE
리서치 댓글 삭제

### DIFF
--- a/src/main/java/com/bss/bssserverapi/domain/comment/Comment.java
+++ b/src/main/java/com/bss/bssserverapi/domain/comment/Comment.java
@@ -4,16 +4,19 @@ import com.bss.bssserverapi.domain.research.Research;
 import com.bss.bssserverapi.domain.user.User;
 import com.bss.bssserverapi.global.common.DateTimeField;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@Table(name = "comments")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment extends DateTimeField {
 
@@ -25,6 +28,11 @@ public class Comment extends DateTimeField {
     private String content;
 
     private Long childCommentCount = 0L;
+
+    @NotNull
+    private Boolean isDeleted = Boolean.FALSE;
+
+    private LocalDateTime deletedAt;
 
     @ManyToOne
     @JoinColumn(name = "user_id")
@@ -64,5 +72,13 @@ public class Comment extends DateTimeField {
     public void update(String content) {
 
         this.content = content;
+    }
+
+    public void softDelete() {
+
+        this.isDeleted = Boolean.TRUE;
+        this.deletedAt = LocalDateTime.now();
+
+        this.research.minusComment();
     }
 }

--- a/src/main/java/com/bss/bssserverapi/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/bss/bssserverapi/domain/comment/controller/CommentController.java
@@ -65,4 +65,16 @@ public class CommentController {
                 .status(HttpStatus.OK)
                 .body(commentService.updateComment(userName, commentId, updateCommentReqDto));
     }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<?> deleteComment(
+            @AuthenticationPrincipal final String userName,
+            @PathVariable("commentId") final Long commentId){
+
+        commentService.deleteComment(userName, commentId);
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
 }

--- a/src/main/java/com/bss/bssserverapi/domain/comment/dto/GetCommentResDto.java
+++ b/src/main/java/com/bss/bssserverapi/domain/comment/dto/GetCommentResDto.java
@@ -14,16 +14,18 @@ public class GetCommentResDto {
     private String content;
     private String userName;
     private Long childCommentCount;
+    private Boolean isDeleted;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<GetCommentResDto> getReplyCommentResDtoList = new ArrayList<>();
 
-    public GetCommentResDto(final Long id, final String content, final String userName, final Long childCommentCount, final LocalDateTime createdAt, final LocalDateTime updatedAt, final List<GetCommentResDto> getReplyCommentResDtoList) {
+    public GetCommentResDto(final Long id, final String content, final String userName, final Long childCommentCount, final Boolean isDeleted, final LocalDateTime createdAt, final LocalDateTime updatedAt, final List<GetCommentResDto> getReplyCommentResDtoList) {
 
         this.id = id;
         this.content = content;
         this.userName = userName;
         this.childCommentCount = childCommentCount;
+        this.isDeleted = isDeleted;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.getReplyCommentResDtoList = getReplyCommentResDtoList;
@@ -40,6 +42,7 @@ public class GetCommentResDto {
                 comment.getContent(),
                 comment.getUser().getUserName(),
                 comment.getChildCommentCount(),
+                comment.getIsDeleted(),
                 comment.getCreatedAt(),
                 comment.getUpdatedAt(),
                 getCommentResDtoList

--- a/src/main/java/com/bss/bssserverapi/domain/comment/dto/GetCommentResDto.java
+++ b/src/main/java/com/bss/bssserverapi/domain/comment/dto/GetCommentResDto.java
@@ -15,17 +15,19 @@ public class GetCommentResDto {
     private String userName;
     private Long childCommentCount;
     private Boolean isDeleted;
+    private LocalDateTime deletedAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private List<GetCommentResDto> getReplyCommentResDtoList = new ArrayList<>();
 
-    public GetCommentResDto(final Long id, final String content, final String userName, final Long childCommentCount, final Boolean isDeleted, final LocalDateTime createdAt, final LocalDateTime updatedAt, final List<GetCommentResDto> getReplyCommentResDtoList) {
+    public GetCommentResDto(final Long id, final String content, final String userName, final Long childCommentCount, final Boolean isDeleted, final LocalDateTime deletedAt, final LocalDateTime createdAt, final LocalDateTime updatedAt, final List<GetCommentResDto> getReplyCommentResDtoList) {
 
         this.id = id;
         this.content = content;
         this.userName = userName;
         this.childCommentCount = childCommentCount;
         this.isDeleted = isDeleted;
+        this.deletedAt = deletedAt;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
         this.getReplyCommentResDtoList = getReplyCommentResDtoList;
@@ -43,6 +45,7 @@ public class GetCommentResDto {
                 comment.getUser().getUserName(),
                 comment.getChildCommentCount(),
                 comment.getIsDeleted(),
+                comment.getDeletedAt(),
                 comment.getCreatedAt(),
                 comment.getUpdatedAt(),
                 getCommentResDtoList

--- a/src/main/java/com/bss/bssserverapi/domain/comment/dto/GetCommentResDto.java
+++ b/src/main/java/com/bss/bssserverapi/domain/comment/dto/GetCommentResDto.java
@@ -41,7 +41,7 @@ public class GetCommentResDto {
 
         return new GetCommentResDto(
                 comment.getId(),
-                comment.getContent(),
+                (comment.getIsDeleted().equals(Boolean.TRUE) ? "삭제된 댓글입니다. " : comment.getContent()),
                 comment.getUser().getUserName(),
                 comment.getChildCommentCount(),
                 comment.getIsDeleted(),
@@ -55,5 +55,10 @@ public class GetCommentResDto {
     public void setGetReplyCommentResDtoList(final List<GetCommentResDto> getReplyCommentResDtoList){
 
         this.getReplyCommentResDtoList = getReplyCommentResDtoList;
+    }
+
+    public void setContent(final String content) {
+
+        this.content = content;
     }
 }

--- a/src/main/java/com/bss/bssserverapi/domain/research/Research.java
+++ b/src/main/java/com/bss/bssserverapi/domain/research/Research.java
@@ -101,4 +101,9 @@ public class Research extends DateTimeField {
 
         this.commentCount++;
     }
+
+    public void minusComment() {
+
+        this.commentCount--;
+    }
 }


### PR DESCRIPTION
## Issue
- close #68
## 💡 구현 기능
- 댓글 삭제
- 권한 검증(댓글 작성자 본인 또는 리서치 작성자만 가능)
- 소프트 딜리트로 구현
- 삭제된 댓글은 일관된 메시지로 content 변경
- 리서치에는 댓글 개수 차감
## ⁉️ 기타

## ⏰ 소요 시간
- 추정 시간: 1h
- 소요 시간: 1h