### PR TITLE
Refactor/issue 82 리서치 페이징 조회 성능 개선 (N + 1문제 해결)

### DIFF
--- a/src/main/java/com/bss/bssserverapi/domain/research/Research.java
+++ b/src/main/java/com/bss/bssserverapi/domain/research/Research.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -50,6 +51,7 @@ public class Research extends DateTimeField {
     @JoinColumn(name = "stock_id")
     private Stock stock;
 
+    @BatchSize(size = 10)
     @OneToMany(mappedBy = "research", cascade = CascadeType.PERSIST)
     private List<ResearchTag> researchTagList = new ArrayList<>();
 

--- a/src/main/java/com/bss/bssserverapi/domain/research/repository/ResearchJpaRepository.java
+++ b/src/main/java/com/bss/bssserverapi/domain/research/repository/ResearchJpaRepository.java
@@ -20,11 +20,11 @@ public interface ResearchJpaRepository extends JpaRepository<Research, Long> {
                                          @Param("limit") final Long limit,
                                          @Param("lastResearchId") final Long lastResearchId);
 
-    @Query("SELECT r FROM Research r WHERE r.stock.id = :stockId ORDER BY r.id DESC LIMIT :limit")
+    @Query("SELECT r FROM Research r LEFT JOIN FETCH r.user WHERE r.stock.id = :stockId ORDER BY r.id DESC LIMIT :limit")
     List<Research> findFirstPageByStockId(@Param("stockId") final Long stockId,
                                           @Param("limit") final Long limit);
 
-    @Query("SELECT r FROM Research r WHERE r.stock.id = :stockId AND r.id < :lastResearchId ORDER BY r.id DESC LIMIT :limit")
+    @Query("SELECT r FROM Research r LEFT JOIN FETCH r.user WHERE r.stock.id = :stockId AND r.id < :lastResearchId ORDER BY r.id DESC LIMIT :limit")
     List<Research> findNextPageByStockId(@Param("stockId") final Long stockId,
                                          @Param("limit") final Long limit,
                                          @Param("lastResearchId") final Long lastResearchId);

--- a/src/main/java/com/bss/bssserverapi/domain/research/service/ResearchService.java
+++ b/src/main/java/com/bss/bssserverapi/domain/research/service/ResearchService.java
@@ -19,14 +19,15 @@ import com.bss.bssserverapi.domain.user.repository.UserJpaRepository;
 import com.bss.bssserverapi.global.exception.ErrorCode;
 import com.bss.bssserverapi.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -140,7 +141,7 @@ public class ResearchService {
 
         final List<GetResearchPreviewResDto> list = researchList.stream()
                 .map(research -> {
-                    List<Tag> tagList = researchTagRepository.findResearchTagsByResearchId(research.getId())
+                    List<Tag> tagList = research.getResearchTagList()
                             .stream()
                             .map(ResearchTag::getTag)
                             .toList();

--- a/src/main/java/com/bss/bssserverapi/domain/tag/Tag.java
+++ b/src/main/java/com/bss/bssserverapi/domain/tag/Tag.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@BatchSize(size = 50)
 @Getter
 @Entity
 @EntityListeners(AuditingEntityListener.class)

--- a/src/test/java/com/bss/bssserverapi/research/ResearchServiceTest.java
+++ b/src/test/java/com/bss/bssserverapi/research/ResearchServiceTest.java
@@ -225,14 +225,6 @@ class ResearchServiceTest {
         when(stockRepository.findStockById(stockId)).thenReturn(Optional.of(stock));
         when(researchJpaRepository.findFirstPageByStockId(stockId, BATCH_SIZE))
                 .thenReturn(researchList);
-        for(Research research : researchList){
-            when(researchTagRepository.findResearchTagsByResearchId(research.getId()))
-                    .thenReturn(tagList.stream().map(tag -> {
-                        ResearchTag rt = new ResearchTag();
-                        rt.setTag(tag);
-                        return rt;
-                    }).toList());
-        }
 
         // when
         GetResearchPagingResDto res = researchService.getResearchPagingByStock(stockId, 10L, 0L);
@@ -263,14 +255,6 @@ class ResearchServiceTest {
         when(stockRepository.findStockById(stockId)).thenReturn(Optional.of(stock));
         when(researchJpaRepository.findNextPageByStockId(stockId, BATCH_SIZE, 5L))
                 .thenReturn(researchList);
-        for(Research research : researchList){
-            when(researchTagRepository.findResearchTagsByResearchId(research.getId()))
-                    .thenReturn(tagList.stream().map(tag -> {
-                        ResearchTag rt = new ResearchTag();
-                        rt.setTag(tag);
-                        return rt;
-                    }).toList());
-        }
 
         // when
         GetResearchPagingResDto res = researchService.getResearchPagingByStock(stockId, 10L, 5L);


### PR DESCRIPTION
## Issue
- close #82
## 💡 구현 기능
- Research 페이징 조회시 발생하는 N + 1 문제 해결
쿼리 개수 72개 -> 4개로 개선
FetchJoin과 BatchSize 혼합 사용
## ⁉️ 기타
- 현재 byStock만 적용하였고, byUser는 아직 하지 않았습니다.
- LEFT JOIN FETCH과 JOIN FETCH의 성능 차이에 대한 학습이 필요합니다.(EXPLAIN ANALYZE로 분석 결과 LEFT JOIN FETCH의 경우 SELECT 후에 JOIN이 이루어졌습니다. 관련하여 추가 학습이 필요합니다.)
- repository 계층 테스트를 수행하지 않았습니다.
## ⏰ 소요 시간
- 추정 시간: 4h
- 소요 시간: 10h(학습 2h + 개발 1h + 정리 7h)